### PR TITLE
Update settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,31 @@
 {
-  "dotnet.defaultSolution": "AZ2003App.sln"
+    "chat.modeFilesLocations": {
+    "chatmodes": true
+  },
+  "chat.promptFilesLocations": {
+    "prompts": true
+  },
+  "chat.instructionsFilesLocations": {
+    "instructions": true
+  },
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false,
+    "editor.formatOnSave": true
+  },
+  "editor.rulers": [
+    100
+  ],
+  // "files.associations": {
+  //   "*.chatmode.md": "markdown",
+  //   "*.instructions.md": "markdown",
+  //   "*.prompt.md": "markdown"
+  // },
+  "github.copilot.chat.commitMessageGeneration.instructions": [
+    {
+      "text": "The first line should be summary of no more than 50 characters starting with classification of commit from: `CHORE:`|`FIX:`|`CHANGE:`|`BREAKING CHANGE:`|`TESTS:`|`SECURITY:`|`COMPLEX:`. The second line should be blank. The following lines should be the full summary with each item starting with a `-`. Any summary item that is security related should start with `SECURITY:`. Any summary item change that causes a breaking change to a feature/interface/dependency should start with `BREAKING CHANGE:`"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the `.vscode/settings.json` file to introduce new configurations for managing chat-related files, enforce consistent file formatting, and provide guidelines for commit message generation.

### New configurations for chat-related files:
* Added settings for `chat.modeFilesLocations`, `chat.promptFilesLocations`, and `chat.instructionsFilesLocations` to manage chat-related files (`chatmodes`, `prompts`, and `instructions`).

### File formatting improvements:
* Enabled settings to enforce consistent end-of-line characters (`\n`), insert a final newline at the end of files, and trim trailing whitespace. Exceptions are made for Markdown files, where trailing whitespace is preserved, and formatting is applied on save.

### Editor enhancements:
* Configured a ruler at 100 characters to assist with code readability.

### Commit message guidelines:
* Added instructions for generating commit messages with a structured format, including classifications like `CHORE:`, `FIX:`, and `BREAKING CHANGE:`, as well as security and breaking change markers.